### PR TITLE
feat: add Git push validator for safe push operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ GitHubリポジトリから直接実行する最もシンプルな方法です�
 
 この設定では、MCP経由でCodexツールを実行する際の安全性をチェックします。
 
+#### Git Pushバリデータ
+
+```json
+# .claude/hooks.json
+{
+  "hooks": [
+    {
+      "eventName": "PreToolUse",
+      "command": "uvx --from git+https://github.com/syou6162/cc-pre-tool-use-hook-judge cc-pre-tool-use-hook-judge --builtin validate_git_push"
+    }
+  ]
+}
+```
+
+この設定では、全てのツール実行前にGit pushバリデータが動作します。
+
 ### cchookと組み合わせて使う（推奨）
 
 [cchook](https://github.com/syou6162/cchook)と組み合わせることで、特定のコマンドのみをバリデートできます：
@@ -88,6 +104,23 @@ preToolUse:
 ```
 
 この設定により、MCP Codexツールの実行時のみがバリデーションの対象になります。
+
+#### Git Pushバリデータ
+
+```yaml
+# .cchook/config.yaml
+preToolUse:
+  - matcher: "Bash"
+    conditions:
+      - type: command_starts_with
+        value: "git push"
+    actions:
+      - type: command
+        exit_status: 0 # JSON Outputで制御するので、exit_statusはこれでよい
+        command: echo '{.}' | uvx --from git+https://github.com/syou6162/cc-pre-tool-use-hook-judge cc-pre-tool-use-hook-judge --builtin validate_git_push
+```
+
+この設定により、`git push`コマンドのみがバリデーションの対象になります。
 
 ## アーキテクチャ
 
@@ -218,6 +251,23 @@ stdout (JSON)
   - 危険な操作（DDL、DML、DCL、BigQuery ML、危険なオプション）
 - **使用方法**: `--builtin validate_bq_query`で指定
 
+#### 9. `builtin_configs/validate_codex_mcp.yaml`
+- **役割**: Codex MCPバリデータのビルトイン設定
+- **内容**:
+  - MCP経由でCodexツールを実行する際の安全性判定ルール
+  - 安全な設定（read-only sandbox、適切なapproval-policy）
+  - 危険な設定（danger-full-access、approval-policy=never、別ディレクトリでの実行）
+- **使用方法**: `--builtin validate_codex_mcp`で指定
+
+#### 10. `builtin_configs/validate_git_push.yaml`
+- **役割**: Git Pushバリデータのビルトイン設定
+- **内容**:
+  - git pushコマンドの安全性判定ルール
+  - 安全な操作（現在のブランチと同じ名前のリモートブランチへのpush）
+  - 危険な操作（main/masterブランチへのpush、force push、HEADの使用）
+  - Bashツールを使用して現在のブランチ名を確認
+- **使用方法**: `--builtin validate_git_push`で指定
+
 ## コーディング規約
 
 ### 型アノテーション
@@ -290,7 +340,8 @@ uv run cc-pre-tool-use-hook-judge --config custom_validator.yaml
 cc-pre-tool-use-hook-judge/
 ├── builtin_configs/
 │   ├── validate_bq_query.yaml   # BigQueryバリデータ設定
-│   └── validate_codex_mcp.yaml  # Codex MCPバリデータ設定
+│   ├── validate_codex_mcp.yaml  # Codex MCPバリデータ設定
+│   └── validate_git_push.yaml   # Git Pushバリデータ設定
 ├── src/
 │   ├── __init__.py              # 空
 │   ├── __main__.py              # main()関数、CLIエントリーポイント

--- a/README.md
+++ b/README.md
@@ -111,6 +111,59 @@ mcp__codex__codex(prompt="設定を変更して", cwd="/etc")
 # → 理由: 意図しないディレクトリでの操作
 ```
 
+#### Git Pushバリデータ
+
+```json
+# .claude/hooks.json
+{
+  "hooks": [
+    {
+      "eventName": "PreToolUse",
+      "command": "uvx --from git+https://github.com/syou6162/cc-pre-tool-use-hook-judge cc-pre-tool-use-hook-judge --builtin validate_git_push"
+    }
+  ]
+}
+```
+
+この設定では、全てのツール実行前にGit pushバリデータが動作します。
+
+**動作例:**
+
+安全なpush（ALLOW）:
+```bash
+# 現在のブランチ（例: feature/new-feature）をpush
+git push
+# → permissionDecision: "allow"
+# → 理由: 現在のブランチをpush
+
+git push origin feature/new-feature
+# → permissionDecision: "allow"
+# → 理由: 現在のブランチと同じ名前のリモートブランチへのpush
+```
+
+危険なpush（DENY）:
+```bash
+git push origin main
+# → permissionDecision: "deny"
+# → 理由: mainブランチへのpushは禁止
+
+git push origin master
+# → permissionDecision: "deny"
+# → 理由: masterブランチへのpushは禁止
+
+git push --force origin feature/new-feature
+# → permissionDecision: "deny"
+# → 理由: force pushは禁止
+
+git push -f origin feature/new-feature
+# → permissionDecision: "deny"
+# → 理由: force pushは禁止
+
+git push origin HEAD
+# → permissionDecision: "deny"
+# → 理由: HEADの使用は禁止、明示的なブランチ名を指定してください
+```
+
 ### cchookと組み合わせて使う（推奨）
 
 [cchook](https://github.com/syou6162/cchook)を使うと、特定のコマンドのみをバリデートできます：

--- a/builtin_configs/validate_git_push.yaml
+++ b/builtin_configs/validate_git_push.yaml
@@ -1,0 +1,48 @@
+prompt: |
+  あなたはGit操作のセキュリティ専門家です。
+  git pushコマンドの安全性を判定してください。
+
+  # 判定基準
+
+  ## 必ず拒否する操作（permissionDecision: "deny"）
+  1. main/masterブランチへのpush
+     - コマンドに "main" または "master" という文字列が含まれる場合
+     - 例: `git push origin main`, `git push origin master`
+
+  2. force pushの使用
+     - `--force`, `-f`, `--force-with-lease`, `--force-if-includes` などのオプションが含まれる場合
+     - 例: `git push --force`, `git push -f origin feature`
+
+  3. HEADの使用
+     - コマンドに "HEAD" という文字列が含まれる場合
+     - 明示的なブランチ名を使用するべき
+     - 例: `git push origin HEAD`
+
+  ## 許可する操作（permissionDecision: "allow"）
+  1. 現在のブランチと同じ名前のリモートブランチへのpush
+     - まずBashツールで現在のブランチ名を確認: `git rev-parse --abbrev-ref HEAD`
+     - コマンドにブランチ名が明示されていない場合（`git push`のみ）
+     - コマンドに現在のブランチ名と同じ名前が含まれる場合
+     - 例: 現在が`feature/new-feature`の場合、`git push origin feature/new-feature`
+
+  ## その他
+  - **判断不能**: 上記のどちらにも該当しない場合は`deny`
+
+  # 判定手順
+
+  1. **現在のブランチ名を確認**
+     - Bashツールを使用: `git rev-parse --abbrev-ref HEAD`
+     - エラーが発生した場合はその旨を記録
+
+  2. **コマンドのパラメーターを解析**
+     - force pushオプションの有無を確認
+     - main/masterブランチへのpushかどうかを確認
+     - 指定されたブランチ名と現在のブランチ名を比較
+
+  3. **判定基準に従って決定**
+     - 拒否条件に該当する場合は "deny"
+     - 許可条件に該当する場合は "allow"
+     - どちらでもない場合は "deny"
+model: haiku
+allowed_tools:
+  - Bash(git rev-parse --abbrev-ref HEAD:*)


### PR DESCRIPTION
## 概要

Git pushコマンドの安全性を判定するビルトイン設定（`validate_git_push`）を追加しました。本機能により、危険なpush操作（main/masterブランチへのpush、force push、HEADの使用）を事前に防ぐことができます。

## 何をやったか

### 1. ビルトイン設定ファイルの作成
`builtin_configs/validate_git_push.yaml` を新規作成し、Git pushバリデータのプロンプトと設定を定義しました。

**主な機能：**
- **拒否する操作の判定**：
  - main/masterブランチへのpush
  - force push（`--force`, `-f`, `--force-with-lease`, `--force-if-includes`）
  - HEADの明示的な指定

- **許可する操作の判定**：
  - 引数なしの `git push`（現在のブランチをpush）
  - 現在のブランチと同じ名前をリモートに指定した場合（例：現在が `feature/new-feature` の場合、`git push origin feature/new-feature`）

- **判定手順**：
  - Bashツール経由で現在のブランチ名を確認
  - コマンドのパラメーターを解析
  - 判定基準に従って安全性を決定

### 2. ドキュメント更新
- **CLAUDE.md**：
  - 「Claude Codeのデフォルトフックとして使う」セクションにGit Pushバリデータの使用例を追加
  - 「cchookと組み合わせて使う（推奨）」セクションにcchook設定例を追加
  - 「アーキテクチャ」セクションにビルトイン設定説明を追加（セクション10）
  - ファイル構造図を更新

- **README.md**：
  - Git Pushバリデータの詳細な動作例を追加
  - 安全なpushと危険なpushの具体例を記載

## 修正が必要になった背景

Claude Codeの開発ガイドで、main/masterブランチへの不用意なpushを防ぐための仕組みを実装する必要がありました。また、git pushの安全性判定機能は、本プロジェクトのセキュリティ優先の設計思想を体現した重要な機能です。

## 動作確認

本機能を使用する際は、以下のいずれかの方法で設定できます：

```json
# .claude/hooks.jsonで設定する場合
{
  "hooks": [
    {
      "eventName": "PreToolUse",
      "command": "uvx --from git+https://github.com/syou6162/cc-pre-tool-use-hook-judge cc-pre-tool-use-hook-judge --builtin validate_git_push"
    }
  ]
}
```

```yaml
# cchook設定ファイルで設定する場合
preToolUse:
  - matcher: "Bash"
    conditions:
      - type: command_starts_with
        value: "git push"
    actions:
      - type: command
        exit_status: 0
        command: echo '{.}' | uvx --from git+https://github.com/syou6162/cc-pre-tool-use-hook-judge cc-pre-tool-use-hook-judge --builtin validate_git_push
```

## テストプラン

- [x] ビルトイン設定ファイルが正しく読み込まれることを確認
- [x] main/masterブランチへのpushが拒否されることを確認
- [x] force pushが拒否されることを確認
- [x] HEADの使用が拒否されることを確認
- [x] 現在のブランチへのpushが許可されることを確認
- [x] ドキュメントが正確に記載されていることを確認
