### PR TITLE
ci: update astral-sh/setup-uv action to v5.4.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 


### PR DESCRIPTION
## 概要

GitHub Actionsの`astral-sh/setup-uv`アクションのバージョンハッシュを、v5.0.0から最新のv5.4.2に更新しました。

## 修正内容

- `.github/workflows/tests.yml`内の`setup-uv`アクションのハッシュを更新
- `e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5` → `d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2`

## 背景

GitHub Actionsの依存関係を最新の安定版に保つことで、セキュリティパッチやバグ修正の恩恵を受けられます。
