### PR TITLE
fix(schema): Claude Codeの最新PreToolUse hook仕様に追従する

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -27,13 +27,16 @@ PRETOOLUSE_OUTPUT_SCHEMA = {
                 },
                 "permissionDecision": {
                     "type": "string",
-                    "enum": ["allow", "deny", "ask"]
+                    "enum": ["allow", "deny", "ask", "defer"]
                 },
                 "permissionDecisionReason": {
                     "type": "string"
                 },
                 "updatedInput": {
                     "type": "object"
+                },
+                "additionalContext": {
+                    "type": "string"
                 }
             },
             "additionalProperties": False
@@ -74,7 +77,14 @@ PRETOOLUSE_INPUT_SCHEMA = {
         "cwd": {"type": "string"},
         "permission_mode": {
             "type": "string",
-            "enum": ["default", "plan", "acceptEdits", "bypassPermissions"]
+            "enum": [
+                "default",
+                "plan",
+                "acceptEdits",
+                "auto",
+                "dontAsk",
+                "bypassPermissions"
+            ]
         },
         "hook_event_name": {
             "type": "string",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -92,6 +92,40 @@ class TestPreToolUseInputValidation:
         result = validate_pretooluse_input(input_data)
         assert result == input_data
 
+    @pytest.mark.parametrize(
+        "permission_mode",
+        ["default", "plan", "acceptEdits", "auto", "dontAsk", "bypassPermissions"],
+    )
+    def test_valid_permission_modes(self, permission_mode: str) -> None:
+        """Claude Codeがサポートする全permission_mode値でバリデーションが成功することを確認"""
+        input_data = {
+            "session_id": "abc123",
+            "transcript_path": "/Users/test/.claude/projects/test/session.jsonl",
+            "cwd": "/Users/test",
+            "permission_mode": permission_mode,
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"}
+        }
+
+        result = validate_pretooluse_input(input_data)
+        assert result == input_data
+
+    def test_invalid_permission_mode(self) -> None:
+        """未知のpermission_mode値に対してエラーを返すことを確認"""
+        input_data = {
+            "session_id": "abc123",
+            "transcript_path": "/Users/test/.claude/projects/test/session.jsonl",
+            "cwd": "/Users/test",
+            "permission_mode": "unknownMode",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"}
+        }
+
+        with pytest.raises(ValueError):
+            validate_pretooluse_input(input_data)
+
     def test_empty_dict_raises_error(self) -> None:
         """空の辞書に対してエラーを返すことを確認"""
         with pytest.raises(ValueError):
@@ -170,6 +204,33 @@ class TestPreToolUseOutputValidation:
                 "updatedInput": {
                     "file_path": "/modified/path.txt"
                 }
+            }
+        }
+
+        result = validate_pretooluse_output(output_data)
+        assert result == output_data
+
+    def test_valid_output_with_defer_decision(self) -> None:
+        """permissionDecisionがdeferの有効な出力に対してバリデーションが成功することを確認"""
+        output_data = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "defer",
+                "permissionDecisionReason": "Defer to the default permission flow"
+            }
+        }
+
+        result = validate_pretooluse_output(output_data)
+        assert result == output_data
+
+    def test_valid_output_with_additional_context(self) -> None:
+        """additionalContextを含む有効な出力に対してバリデーションが成功することを確認"""
+        output_data = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "Sanitized",
+                "additionalContext": "Command sanitized: added --fix flag"
             }
         }
 


### PR DESCRIPTION
## 概要

Claude Codeの最新PreToolUse hook仕様にスキーマを追従させ、`dontAsk`/`auto` パーミッションモードで全ツールがdenyされる不具合を修正します。

## 背景・問題

Claude Codeが `permission_mode` に新モード（`auto`, `dontAsk`）を追加しましたが、入力スキーマが古い4値（`default`/`plan`/`acceptEdits`/`bypassPermissions`）のままでした。そのため、これらの新モードで動作すると入力検証が `ValueError` になり、`__main__.py` の `except ValueError` 経由で**全ツールが問答無用でdeny**されていました。

このバリデータ自身がuvx経由で `validate_git_push` 等として動くため、`git push` すらブロックされる自己言及的な症状になっていました。

## 変更内容

公式の最新仕様（https://code.claude.com/docs/en/hooks）に合わせて `src/schema.py` を更新:

- 入力スキーマ `PRETOOLUSE_INPUT_SCHEMA` の `permission_mode` enum に `auto`, `dontAsk` を追加
- 出力スキーマ `PRETOOLUSE_OUTPUT_SCHEMA` の `permissionDecision` enum に `defer` を追加
- 出力スキーマの `hookSpecificOutput` に `additionalContext` プロパティを追加

## テスト

TDD（Red→Green）で実施:

- 全 `permission_mode` 値のparametrizeテストと不正値の拒否テストを追加
- `defer` 決定・`additionalContext` を含む出力のテストを追加
- 全72テスト pass / mypy clean / ruff clean

## 関連情報

- Claude Code Hooks reference: https://code.claude.com/docs/en/hooks
